### PR TITLE
Implement CRUD endpoints for role screens management

### DIFF
--- a/controllers/rol/screens_controller.py
+++ b/controllers/rol/screens_controller.py
@@ -1,0 +1,483 @@
+from flask_restful import Resource
+from flask import request
+from utils.server_response import ServerResponse, StatusCode
+from models.role.role import RoleModel
+from utils.jwt_manager import validate_jwt
+import logging
+
+class ScreensController(Resource):
+    route = "/rol/screens"
+
+    """
+    POST /rol/screens - Asignar screens a un rol
+    """
+    def post(self):
+        try:
+            # Validar autenticación
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith('Bearer '):
+                return ServerResponse(
+                    message="Authorization header required",
+                    message_code="AUTH_REQUIRED",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            token = auth_header.split(' ')[1]
+            jwt_data = validate_jwt(token)
+            if not jwt_data:
+                return ServerResponse(
+                    message="Invalid or expired token",
+                    message_code="INVALID_TOKEN",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            admin_id = jwt_data['identity']
+
+            # Obtener datos del request
+            data = request.get_json()
+            role_id = data.get("role_id")
+            app_id = data.get("app_id")
+            screen_path = data.get("screen_path")
+
+            # Validar campos requeridos
+            if not role_id:
+                return ServerResponse(
+                    message="Role ID is required",
+                    message_code="INVALID_ROLE_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not app_id:
+                return ServerResponse(
+                    message="Application ID is required",
+                    message_code="INVALID_APP_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not screen_path:
+                return ServerResponse(
+                    message="Screen path is required",
+                    message_code="INVALID_SCREEN_PATH",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            # Buscar el rol por ID
+            role = RoleModel.get_by_id(role_id)
+            if not role:
+                return ServerResponse(
+                    message="Role not found",
+                    message_code="ROLE_NOT_FOUND",
+                    status=StatusCode.NOT_FOUND
+                ).to_response()
+
+            # Validar que el admin que creó el rol sea el que lo está modificando
+            if role.admin_id != admin_id:
+                return ServerResponse(
+                    message="You can only modify roles that you created",
+                    message_code="UNAUTHORIZED_MODIFY",
+                    status=StatusCode.FORBIDDEN
+                ).to_response()
+
+            # Validar que el rol pertenezca a la aplicación especificada
+            if str(role.app_id) != str(app_id):
+                return ServerResponse(
+                    message="Role does not belong to the specified application",
+                    message_code="ROLE_APP_MISMATCH",
+                    status=StatusCode.BAD_REQUEST
+                ).to_response()
+
+            # Agregar la screen al rol usando el ID del rol directamente
+            updated_role = RoleModel.add_screens_by_role_id(role_id, [screen_path])
+
+            if not updated_role:
+                return ServerResponse(
+                    message="Failed to add screen to role",
+                    message_code="ADD_SCREEN_FAILED",
+                    status=StatusCode.INTERNAL_SERVER_ERROR
+                ).to_response()
+            
+            if updated_role == "DUPLICATE":
+                return ServerResponse(
+                    message="Screen already exists in this role",
+                    message_code="DUPLICATE_SCREEN",
+                    status=StatusCode.CONFLICT
+                ).to_response()
+
+            return ServerResponse(
+                data=updated_role.to_dict(),
+                message="Screen assigned successfully",
+                message_code="SCREEN_ASSIGNED",
+                status=StatusCode.OK
+            ).to_response()
+
+        except Exception as e:
+            logging.error(f"Error assigning screen: {str(e)}", exc_info=True)
+            return ServerResponse(
+                message="Internal server error",
+                message_code="INTERNAL_SERVER_ERROR",
+                status=StatusCode.INTERNAL_SERVER_ERROR
+            ).to_response()
+
+    """
+    GET /rol/screens - Obtener screens de un rol
+    """
+    def get(self):
+        try:
+            # Validar autenticación
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith('Bearer '):
+                return ServerResponse(
+                    message="Authorization header required",
+                    message_code="AUTH_REQUIRED",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            token = auth_header.split(' ')[1]
+            jwt_data = validate_jwt(token)
+            if not jwt_data:
+                return ServerResponse(
+                    message="Invalid or expired token",
+                    message_code="INVALID_TOKEN",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            admin_id = jwt_data['identity']
+
+            # Obtener parámetros de query
+            role_id = request.args.get('role_id')
+            app_id = request.args.get('app_id')
+
+            if not role_id:
+                return ServerResponse(
+                    message="Role ID is required",
+                    message_code="INVALID_ROLE_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not app_id:
+                return ServerResponse(
+                    message="Application ID is required",
+                    message_code="INVALID_APP_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            # Buscar el rol por ID
+            role = RoleModel.get_by_id(role_id)
+            if not role:
+                return ServerResponse(
+                    message="Role not found",
+                    message_code="ROLE_NOT_FOUND",
+                    status=StatusCode.NOT_FOUND
+                ).to_response()
+
+            # Validar que el admin que creó el rol sea el que lo está consultando
+            if role.admin_id != admin_id:
+                return ServerResponse(
+                    message="You can only view roles that you created",
+                    message_code="UNAUTHORIZED_VIEW",
+                    status=StatusCode.FORBIDDEN
+                ).to_response()
+
+            # Validar que el rol pertenezca a la aplicación especificada
+            if str(role.app_id) != str(app_id):
+                return ServerResponse(
+                    message="Role does not belong to the specified application",
+                    message_code="ROLE_APP_MISMATCH",
+                    status=StatusCode.BAD_REQUEST
+                ).to_response()
+
+            return ServerResponse(
+                data={
+                    "role_id": role_id,
+                    "app_id": app_id,
+                    "screens": role.screens or []
+                },
+                message="Screens retrieved successfully",
+                message_code="SCREENS_RETRIEVED",
+                status=StatusCode.OK
+            ).to_response()
+
+        except Exception as e:
+            logging.error(f"Error getting screens: {str(e)}", exc_info=True)
+            return ServerResponse(
+                message="Internal server error",
+                message_code="INTERNAL_SERVER_ERROR",
+                status=StatusCode.INTERNAL_SERVER_ERROR
+            ).to_response()
+
+    """
+    DELETE /rol/screens - Eliminar screens de un rol
+    """
+    def delete(self):
+        try:
+            # Validar autenticación
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith('Bearer '):
+                return ServerResponse(
+                    message="Authorization header required",
+                    message_code="AUTH_REQUIRED",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            token = auth_header.split(' ')[1]
+            jwt_data = validate_jwt(token)
+            if not jwt_data:
+                return ServerResponse(
+                    message="Invalid or expired token",
+                    message_code="INVALID_TOKEN",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            admin_id = jwt_data['identity']
+
+            # Obtener datos del request
+            data = request.get_json()
+            role_id = data.get("role_id")
+            app_id = data.get("app_id")
+            screen_path = data.get("screen_path")
+
+            # Validar campos requeridos
+            if not role_id:
+                return ServerResponse(
+                    message="Role ID is required",
+                    message_code="INVALID_ROLE_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not app_id:
+                return ServerResponse(
+                    message="Application ID is required",
+                    message_code="INVALID_APP_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not screen_path:
+                return ServerResponse(
+                    message="Screen path is required",
+                    message_code="INVALID_SCREEN_PATH",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            # Buscar el rol por ID
+            role = RoleModel.get_by_id(role_id)
+            if not role:
+                return ServerResponse(
+                    message="Role not found",
+                    message_code="ROLE_NOT_FOUND",
+                    status=StatusCode.NOT_FOUND
+                ).to_response()
+
+            # Validar que el admin que creó el rol sea el que lo está modificando
+            if role.admin_id != admin_id:
+                return ServerResponse(
+                    message="You can only modify roles that you created",
+                    message_code="UNAUTHORIZED_MODIFY",
+                    status=StatusCode.FORBIDDEN
+                ).to_response()
+
+            # Validar que el rol pertenezca a la aplicación especificada
+            if str(role.app_id) != str(app_id):
+                return ServerResponse(
+                    message="Role does not belong to the specified application",
+                    message_code="ROLE_APP_MISMATCH",
+                    status=StatusCode.BAD_REQUEST
+                ).to_response()
+
+            # Eliminar la screen del rol
+            updated_role = RoleModel.remove_screen_by_role_id(role_id, screen_path)
+
+            if not updated_role:
+                return ServerResponse(
+                    message="Failed to remove screen from role",
+                    message_code="REMOVE_SCREEN_FAILED",
+                    status=StatusCode.INTERNAL_SERVER_ERROR
+                ).to_response()
+            
+            if updated_role == "NOT_FOUND":
+                return ServerResponse(
+                    message="Screen not found in this role",
+                    message_code="SCREEN_NOT_FOUND",
+                    status=StatusCode.NOT_FOUND
+                ).to_response()
+
+            return ServerResponse(
+                data=updated_role.to_dict(),
+                message="Screen removed successfully",
+                message_code="SCREEN_REMOVED",
+                status=StatusCode.OK
+            ).to_response()
+
+        except Exception as e:
+            logging.error(f"Error removing screen: {str(e)}", exc_info=True)
+            return ServerResponse(
+                message="Internal server error",
+                message_code="INTERNAL_SERVER_ERROR",
+                status=StatusCode.INTERNAL_SERVER_ERROR
+            ).to_response()
+
+    """
+    PATCH /rol/screens - Actualizar/reemplazar screens de un rol
+    """
+    def patch(self):
+        try:
+            # Validar autenticación
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith('Bearer '):
+                return ServerResponse(
+                    message="Authorization header required",
+                    message_code="AUTH_REQUIRED",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            token = auth_header.split(' ')[1]
+            jwt_data = validate_jwt(token)
+            if not jwt_data:
+                return ServerResponse(
+                    message="Invalid or expired token",
+                    message_code="INVALID_TOKEN",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            admin_id = jwt_data['identity']
+
+            # Obtener datos del request
+            data = request.get_json()
+            role_id = data.get("role_id")
+            app_id = data.get("app_id")
+            screens = data.get("screens")
+
+            # Validar campos requeridos
+            if not role_id:
+                return ServerResponse(
+                    message="Role ID is required",
+                    message_code="INVALID_ROLE_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not app_id:
+                return ServerResponse(
+                    message="Application ID is required",
+                    message_code="INVALID_APP_ID",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            if not isinstance(screens, list):
+                return ServerResponse(
+                    message="Screens must be a list",
+                    message_code="INVALID_SCREENS_FORMAT",
+                    status=StatusCode.UNPROCESSABLE_ENTITY
+                ).to_response()
+
+            # Buscar el rol por ID
+            role = RoleModel.get_by_id(role_id)
+            if not role:
+                return ServerResponse(
+                    message="Role not found",
+                    message_code="ROLE_NOT_FOUND",
+                    status=StatusCode.NOT_FOUND
+                ).to_response()
+
+            # Validar que el admin que creó el rol sea el que lo está modificando
+            if role.admin_id != admin_id:
+                return ServerResponse(
+                    message="You can only modify roles that you created",
+                    message_code="UNAUTHORIZED_MODIFY",
+                    status=StatusCode.FORBIDDEN
+                ).to_response()
+
+            # Validar que el rol pertenezca a la aplicación especificada
+            if str(role.app_id) != str(app_id):
+                return ServerResponse(
+                    message="Role does not belong to the specified application",
+                    message_code="ROLE_APP_MISMATCH",
+                    status=StatusCode.BAD_REQUEST
+                ).to_response()
+
+            # Actualizar las screens del rol
+            updated_role = RoleModel.update_screens_by_role_id(role_id, screens)
+
+            if not updated_role:
+                return ServerResponse(
+                    message="Failed to update screens for role",
+                    message_code="UPDATE_SCREENS_FAILED",
+                    status=StatusCode.INTERNAL_SERVER_ERROR
+                ).to_response()
+
+            return ServerResponse(
+                data=updated_role.to_dict(),
+                message="Screens updated successfully",
+                message_code="SCREENS_UPDATED",
+                status=StatusCode.OK
+            ).to_response()
+
+        except Exception as e:
+            logging.error(f"Error updating screens: {str(e)}", exc_info=True)
+            return ServerResponse(
+                message="Internal server error",
+                message_code="INTERNAL_SERVER_ERROR",
+                status=StatusCode.INTERNAL_SERVER_ERROR
+            ).to_response()
+
+
+class ScreensByRoleController(Resource):
+    route = "/rol/screens/role/<string:role_id>"
+
+    """
+    GET /rol/screens/role/{role_id} - Obtener screens de un rol específico
+    """
+    def get(self, role_id):
+        try:
+            # Validar autenticación
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith('Bearer '):
+                return ServerResponse(
+                    message="Authorization header required",
+                    message_code="AUTH_REQUIRED",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            token = auth_header.split(' ')[1]
+            jwt_data = validate_jwt(token)
+            if not jwt_data:
+                return ServerResponse(
+                    message="Invalid or expired token",
+                    message_code="INVALID_TOKEN",
+                    status=StatusCode.UNAUTHORIZED
+                ).to_response()
+
+            admin_id = jwt_data['identity']
+
+            # Buscar el rol por ID
+            role = RoleModel.get_by_id(role_id)
+            if not role:
+                return ServerResponse(
+                    message="Role not found",
+                    message_code="ROLE_NOT_FOUND",
+                    status=StatusCode.NOT_FOUND
+                ).to_response()
+
+            # Validar que el admin que creó el rol sea el que lo está consultando
+            if role.admin_id != admin_id:
+                return ServerResponse(
+                    message="You can only view roles that you created",
+                    message_code="UNAUTHORIZED_VIEW",
+                    status=StatusCode.FORBIDDEN
+                ).to_response()
+
+            return ServerResponse(
+                data={
+                    "role_id": role_id,
+                    "screens": role.screens or []
+                },
+                message="Screens retrieved successfully",
+                message_code="SCREENS_RETRIEVED",
+                status=StatusCode.OK
+            ).to_response()
+
+        except Exception as e:
+            logging.error(f"Error getting screens for role {role_id}: {str(e)}", exc_info=True)
+            return ServerResponse(
+                message="Internal server error",
+                message_code="INTERNAL_SERVER_ERROR",
+                status=StatusCode.INTERNAL_SERVER_ERROR
+            ).to_response()

--- a/postman-guide.md
+++ b/postman-guide.md
@@ -516,7 +516,226 @@ Content-Type: application/json
 
 **Nota de Seguridad:** Solo el `user_admin` que creó el rol puede eliminarlo. Esto previene que un admin elimine roles creados por otros admins.
 
-### **3.4 GET /rol/{id} - Obtener Rol por ID**
+### **3.4 POST /rol/screens - Asignar Screen a Rol**
+**Descripción:** Asigna una nueva screen a un rol específico. Solo el admin que creó el rol puede asignar screens.
+
+**URL:** `http://localhost:5002/rol/screens`
+
+**Método:** `POST`
+
+**Headers:**
+```
+Authorization: Bearer {token}
+Content-Type: application/json
+```
+
+**Body (JSON):**
+```json
+{
+  "role_id": "64f8a1b2c3d4e5f6a7b8c9d1",
+  "app_id": "688cfd1ee07d666bf510137d",
+  "screen_path": "/dashboardAdmin"
+}
+```
+
+**Campos requeridos:**
+- `role_id`: string (ID del rol)
+- `app_id`: string (ID de la aplicación)
+- `screen_path`: string (ruta de la screen, ej: "/dashboardAdmin")
+
+**Respuesta exitosa (200):**
+```json
+{
+  "data": {
+    "_id": "64f8a1b2c3d4e5f6a7b8c9d1",
+    "name": "Manager",
+    "description": "Rol de gerente",
+    "permissions": ["read", "write", "update"],
+    "screens": ["/dashboardAdmin"],
+    "admin_id": "68a50dee109b1accea9c1ab1",
+    "app_id": "688cfd1ee07d666bf510137d"
+  },
+  "message": "Screen assigned successfully",
+  "message_code": "SCREEN_ASSIGNED",
+  "status": 200
+}
+```
+
+**Respuesta si la screen ya existe (409):**
+```json
+{
+  "message": "Screen already exists in this role",
+  "message_code": "DUPLICATE_SCREEN",
+  "status": 409
+}
+```
+
+**Respuesta si el rol no pertenece a la app (400):**
+```json
+{
+  "message": "Role does not belong to the specified application",
+  "message_code": "ROLE_APP_MISMATCH",
+  "status": 400
+}
+```
+
+### **3.5 GET /rol/screens - Obtener Screens de un Rol**
+**Descripción:** Obtiene la lista de screens asignadas a un rol específico. Solo el admin que creó el rol puede consultar.
+
+**URL:** `http://localhost:5002/rol/screens`
+
+**Método:** `GET`
+
+**Headers:**
+```
+Authorization: Bearer {token}
+```
+
+**Query Parameters:**
+- `role_id`: string (ID del rol) - **Requerido**
+- `app_id`: string (ID de la aplicación) - **Requerido**
+
+**Ejemplo:**
+```
+GET http://localhost:5002/rol/screens?role_id=64f8a1b2c3d4e5f6a7b8c9d1&app_id=688cfd1ee07d666bf510137d
+```
+
+**Respuesta exitosa (200):**
+```json
+{
+  "data": {
+    "role_id": "64f8a1b2c3d4e5f6a7b8c9d1",
+    "app_id": "688cfd1ee07d666bf510137d",
+    "screens": ["/dashboardAdmin", "/users", "/reports"]
+  },
+  "message": "Screens retrieved successfully",
+  "message_code": "SCREENS_RETRIEVED",
+  "status": 200
+}
+```
+
+### **3.6 DELETE /rol/screens - Eliminar Screen de un Rol**
+**Descripción:** Elimina una screen específica de un rol. Solo el admin que creó el rol puede eliminar screens.
+
+**URL:** `http://localhost:5002/rol/screens`
+
+**Método:** `DELETE`
+
+**Headers:**
+```
+Authorization: Bearer {token}
+Content-Type: application/json
+```
+
+**Body:**
+```json
+{
+  "role_id": "68a591a5ccab9299d7f4c9f4",
+  "app_id": "68a590ecec92b4ab68f630d6",
+  "screen_path": "/dashboard"
+}
+```
+
+**Respuesta exitosa (200):**
+```json
+{
+  "data": {
+    "_id": "68a591a5ccab9299d7f4c9f4",
+    "name": "administrator (TEST)",
+    "description": "administrator - Editado en prueba",
+    "permissions": ["write", "delete", "update", "read"],
+    "creation_date": "2025-08-20 09:13:09.619000",
+    "mod_date": "2025-08-21 01:47:52.137000",
+    "is_active": true,
+    "default_role": false,
+    "screens": ["/users", "/reports"],
+    "admin_id": "68a590ebec92b4ab68f630d5",
+    "app_id": "68a590ecec92b4ab68f630d6"
+  },
+  "message": "Screen removed successfully",
+  "message_code": "SCREEN_REMOVED",
+  "status": 200
+}
+```
+
+### **3.7 PATCH /rol/screens - Actualizar Screens de un Rol**
+**Descripción:** Actualiza/reemplaza todas las screens de un rol. Solo el admin que creó el rol puede modificar screens.
+
+**URL:** `http://localhost:5002/rol/screens`
+
+**Método:** `PATCH`
+
+**Headers:**
+```
+Authorization: Bearer {token}
+Content-Type: application/json
+```
+
+**Body:**
+```json
+{
+  "role_id": "68a591a5ccab9299d7f4c9f4",
+  "app_id": "68a590ecec92b4ab68f630d6",
+  "screens": ["/dashboard", "/users", "/reports", "/settings"]
+}
+```
+
+**Respuesta exitosa (200):**
+```json
+{
+  "data": {
+    "_id": "68a591a5ccab9299d7f4c9f4",
+    "name": "administrator (TEST)",
+    "description": "administrator - Editado en prueba",
+    "permissions": ["write", "delete", "update", "read"],
+    "creation_date": "2025-08-20 09:13:09.619000",
+    "mod_date": "2025-08-21 01:47:52.137000",
+    "is_active": true,
+    "default_role": false,
+    "screens": ["/dashboard", "/users", "/reports", "/settings"],
+    "admin_id": "68a590ebec92b4ab68f630d5",
+    "app_id": "68a590ecec92b4ab68f630d6"
+  },
+  "message": "Screens updated successfully",
+  "message_code": "SCREENS_UPDATED",
+  "status": 200
+}
+```
+
+### **3.8 GET /rol/screens/role/{role_id} - Obtener Screens de un Rol Específico**
+**Descripción:** Obtiene la lista de screens asignadas a un rol específico por su ID. Solo el admin que creó el rol puede consultar.
+
+**URL:** `http://localhost:5002/rol/screens/role/{role_id}`
+
+**Método:** `GET`
+
+**Headers:**
+```
+Authorization: Bearer {token}
+```
+
+**Path Parameters:**
+- `role_id`: string (ID del rol) - **Requerido**
+
+**Ejemplo:**
+```
+GET http://localhost:5002/rol/screens/role/68a591a5ccab9299d7f4c9f4
+```
+
+**Respuesta exitosa (200):**
+```json
+{
+  "data": {
+    "role_id": "68a591a5ccab9299d7f4c9f4",
+    "screens": ["/dashboardAdmin", "/users", "/reports"]
+  },
+  "message": "Screens retrieved successfully",
+  "message_code": "SCREENS_RETRIEVED",
+  "status": 200
+}
+```
+
+### **3.9 GET /rol/{id} - Obtener Rol por ID**
 **Descripción:** Obtiene un rol específico por su ID. Solo el admin que creó el rol puede verlo.
 
 **URL:** `http://localhost:5002/rol/{id}`
@@ -550,7 +769,7 @@ Content-Type: application/json
 }
 ```
 
-### **3.5 PATCH /rol/{id} - Actualizar Rol**
+### **3.10 PATCH /rol/{id} - Actualizar Rol**
 **Descripción:** Actualiza un rol existente. Solo el admin que creó el rol puede modificarlo.
 
 **URL:** `http://localhost:5002/rol/{id}`
@@ -609,7 +828,7 @@ Content-Type: application/json
 - **404:** Role not found
 - **422:** Validation errors (nombre duplicado, campos inválidos)
 
-### **3.6 DELETE /rol/{id} - Eliminar Rol por ID**
+### **3.11 DELETE /rol/{id} - Eliminar Rol por ID**
 **Descripción:** Elimina un rol específico por su ID. Solo el admin que creó el rol puede eliminarlo.
 
 **URL:** `http://localhost:5002/rol/{id}`

--- a/service.py
+++ b/service.py
@@ -7,6 +7,7 @@ from controllers.auth.verify_auth import AuthController
 from controllers.auth.refresh_token import RefreshController
 from controllers.rol.rol_controller import RolController
 from controllers.rol.rol_item_controller import RolItemController
+from controllers.rol.screens_controller import ScreensController, ScreensByRoleController
 from controllers.admin.admin_controller import AdminListController, AdminItemController
 from controllers.apps.apps_controller import AppsListController, AppsItemController
 from controllers.user.user_controller import (
@@ -28,6 +29,8 @@ def addServiceLayer(api: Api):
     # Rol
     api.add_resource(RolController, RolController.route)
     api.add_resource(RolItemController, RolItemController.route)
+    api.add_resource(ScreensController, ScreensController.route)
+    api.add_resource(ScreensByRoleController, ScreensByRoleController.route)
 
     #Logout
     api.add_resource(LogoutController,LogoutController.route)

--- a/swagger.yml
+++ b/swagger.yml
@@ -398,6 +398,273 @@ paths:
           description: "Internal Server Error"
           schema: { $ref: "#/definitions/InternalErrorResponse" }
 
+  # ---------- Screens ----------
+  /rol/screens:
+    post:
+      tags: ["Screens"]
+      summary: "Asignar screen a un rol"
+      description: "Asigna una nueva screen a un rol específico. Solo el admin que creó el rol puede asignar screens."
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required: [role_id, app_id, screen_path]
+            properties:
+              role_id:
+                type: string
+                example: "64f8a1b2c3d4e5f6a7b8c9d0"
+                description: "ID del rol al que se asignará la screen"
+              app_id:
+                type: string
+                example: "68a590ecec92b4ab68f630d6"
+                description: "ID de la aplicación a la que pertenece el rol"
+              screen_path:
+                type: string
+                example: "/dashboardAdmin"
+                description: "Ruta de la screen a asignar"
+      responses:
+        "200":
+          description: "Screen assigned successfully"
+          schema:
+            type: object
+            properties:
+              data: { $ref: "#/definitions/RoleGet" }
+              message: { type: string, example: "Screen assigned successfully" }
+              message_code: { type: string, example: "SCREEN_ASSIGNED" }
+              status: { type: integer, example: 200 }
+        "400":
+          description: "Role does not belong to the specified application"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "401":
+          description: "Authorization required"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "403":
+          description: "Unauthorized to modify this role"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "404":
+          description: "Role not found"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "409":
+          description: "Screen already exists in this role"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "422":
+          description: "Validation errors"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "500":
+          description: "Internal Server Error"
+          schema: { $ref: "#/definitions/InternalErrorResponse" }
+    get:
+      tags: ["Screens"]
+      summary: "Obtener screens de un rol"
+      description: "Obtiene la lista de screens asignadas a un rol específico. Solo el admin que creó el rol puede consultar."
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: query
+          name: role_id
+          type: string
+          required: true
+          description: "ID del rol"
+          example: "64f8a1b2c3d4e5f6a7b8c9d0"
+        - in: query
+          name: app_id
+          type: string
+          required: true
+          description: "ID de la aplicación"
+          example: "68a590ecec92b4ab68f630d6"
+      responses:
+        "200":
+          description: "Screens retrieved successfully"
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  role_id: { type: string }
+                  app_id: { type: string }
+                  screens:
+                    type: array
+                    items: { type: string }
+                    example: ["/dashboardAdmin", "/users", "/reports"]
+              message: { type: string, example: "Screens retrieved successfully" }
+              message_code: { type: string, example: "SCREENS_RETRIEVED" }
+              status: { type: integer, example: 200 }
+        "400":
+          description: "Role does not belong to the specified application"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "401":
+          description: "Authorization required"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "403":
+          description: "Unauthorized to view this role"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "404":
+          description: "Role not found"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "422":
+          description: "Validation errors"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "500":
+          description: "Internal Server Error"
+          schema: { $ref: "#/definitions/InternalErrorResponse" }
+
+  /rol/screens:
+    delete:
+      tags: ["Screens"]
+      summary: "Eliminar screen de un rol"
+      description: "Elimina una screen específica de un rol. Solo el admin que creó el rol puede eliminar screens."
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required: ["role_id", "app_id", "screen_path"]
+            properties:
+              role_id:
+                type: string
+                description: "ID del rol"
+                example: "68a591a5ccab9299d7f4c9f4"
+              app_id:
+                type: string
+                description: "ID de la aplicación"
+                example: "68a590ecec92b4ab68f630d6"
+              screen_path:
+                type: string
+                description: "Ruta de la screen a eliminar"
+                example: "/dashboard"
+      responses:
+        "200":
+          description: "Screen removed successfully"
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/definitions/Role"
+              message: { type: string, example: "Screen removed successfully" }
+              message_code: { type: string, example: "SCREEN_REMOVED" }
+              status: { type: integer, example: 200 }
+        "401":
+          description: "Authorization required"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "403":
+          description: "Unauthorized to modify this role"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "404":
+          description: "Role not found or screen not found"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "422":
+          description: "Invalid request data"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "500":
+          description: "Internal Server Error"
+          schema: { $ref: "#/definitions/InternalErrorResponse" }
+
+    patch:
+      tags: ["Screens"]
+      summary: "Actualizar screens de un rol"
+      description: "Actualiza/reemplaza todas las screens de un rol. Solo el admin que creó el rol puede modificar screens."
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required: ["role_id", "app_id", "screens"]
+            properties:
+              role_id:
+                type: string
+                description: "ID del rol"
+                example: "68a591a5ccab9299d7f4c9f4"
+              app_id:
+                type: string
+                description: "ID de la aplicación"
+                example: "68a590ecec92b4ab68f630d6"
+              screens:
+                type: array
+                items: { type: string }
+                description: "Lista completa de screens para el rol"
+                example: ["/dashboard", "/users", "/reports"]
+      responses:
+        "200":
+          description: "Screens updated successfully"
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/definitions/Role"
+              message: { type: string, example: "Screens updated successfully" }
+              message_code: { type: string, example: "SCREENS_UPDATED" }
+              status: { type: integer, example: 200 }
+        "401":
+          description: "Authorization required"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "403":
+          description: "Unauthorized to modify this role"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "404":
+          description: "Role not found"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "422":
+          description: "Invalid request data"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "500":
+          description: "Internal Server Error"
+          schema: { $ref: "#/definitions/InternalErrorResponse" }
+
+  /rol/screens/role/{role_id}:
+    get:
+      tags: ["Screens"]
+      summary: "Obtener screens de un rol específico"
+      description: "Obtiene la lista de screens asignadas a un rol específico por su ID. Solo el admin que creó el rol puede consultar."
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: role_id
+          type: string
+          required: true
+          description: "ID del rol"
+          example: "68a591a5ccab9299d7f4c9f4"
+      responses:
+        "200":
+          description: "Screens retrieved successfully"
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  role_id: { type: string }
+                  screens:
+                    type: array
+                    items: { type: string }
+                    example: ["/dashboardAdmin", "/users", "/reports"]
+              message: { type: string, example: "Screens retrieved successfully" }
+              message_code: { type: string, example: "SCREENS_RETRIEVED" }
+              status: { type: integer, example: 200 }
+        "401":
+          description: "Authorization required"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "403":
+          description: "Unauthorized to view this role"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "404":
+          description: "Role not found"
+          schema: { $ref: "#/definitions/ErrorResponse" }
+        "500":
+          description: "Internal Server Error"
+          schema: { $ref: "#/definitions/InternalErrorResponse" }
+
   # ---------- Users ----------
   /user/enrollment:
     post:


### PR DESCRIPTION
- Add POST /rol/screens to assign screens to roles
- Add GET /rol/screens to retrieve screens with query params
- Add GET /rol/screens/role/{roleId} to get screens by role ID
- Add DELETE /rol/screens to remove specific screens
- Add PATCH /rol/screens to update/replace all screens
- Add RoleModel methods: add_screens_by_role_id, remove_screen_by_role_id, update_screens_by_role_id
- Update service.py to register new controllers
- Update swagger.yml documentation
- Update postman-guide.md with new endpoints

